### PR TITLE
Use echo instead of the deprecated io.debug function for debugging

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -13,7 +13,7 @@ repository = { type = "github", user = "pendletong", repo = "dateformat" }
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = ">= 0.42.0 and <= 2.0.0"
+gleam_stdlib = ">= 0.59.0 and <= 2.0.0"
 birl = ">= 1.7.1 and < 2.0.0"
 gleam_regexp = ">= 1.1.0 and < 2.0.0"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -28,5 +28,5 @@ packages = [
 birdie = { version = ">= 1.2.3 and < 2.0.0" }
 birl = { version = ">= 1.7.1 and < 2.0.0" }
 gleam_regexp = { version = ">= 1.1.0 and < 2.0.0" }
-gleam_stdlib = { version = ">= 0.42.0 and <= 2.0.0" }
+gleam_stdlib = { version = ">= 0.59.0 and <= 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/dateformat.gleam
+++ b/src/dateformat.gleam
@@ -67,37 +67,35 @@ import gleam/string_tree
 @internal
 pub fn main() {
   io.println("Hello from dateformat!")
-  // io.debug(format(
+  // echo format(
   //   //"YYYY YY Q Qo W Wo WW E Do-Mo-yyyy [dd-MM-yyyy] DDDo",
   //   "A a H HH h hh k kk m mm s ss S SS SSS z zz Z ZZ X x",
   //   birl.now(),
-  // ))
+  // )
   list.range(-12, 12)
   |> list.each(fn(i) {
     let dt = birl.add(birl.now(), duration.hours(i))
 
-    io.debug(
-      birl.to_iso8601(dt)
+    echo birl.to_iso8601(dt)
       <> " "
       <> format(
         //"YYYY YY Q Qo W Wo WW E Do-Mo-yyyy [dd-MM-yyyy] DDDo",
         "A a H HH h hh k kk m mm s ss S SS SSS Z ZZ zz X x",
         dt,
       )
-      |> result.unwrap(""),
-    )
+      |> result.unwrap("")
   })
   birl.parse("20120214T15:30:17.123+00:00")
   |> result.unwrap(birl.now())
   |> birl.get_offset
-  |> io.debug
+  |> echo
   birl.from_unix_milli(1_234_567_890_123)
   |> birl.to_iso8601
-  |> io.debug
+  |> echo
 
   let t = birl.from_unix_milli(1_234_567_890_123)
 
-  format("DD-MMM-YYYY HH:mm", t) |> io.debug
+  format("DD-MMM-YYYY HH:mm", t) |> echo
 }
 
 /// Formats the given Time using the specified format


### PR DESCRIPTION
This changeset swaps out the use of stdlib's `io.debug` function with the `echo` keyword so that stdlib v0.61 and later can be used. At time of writing, the current version of stdlib is v0.62.1.

In [Gleam v1.9](https://gleam.run/news/hello-echo-hello-git/) the `echo` keyword was introduced to replace stdlib's `io.debug` function.

Since stdlib v0.59 `io.debug` has been deprecated and removed from internal use, and in v0.61 `io.debug` was removed from stdlib.

I've made the bare minimum changes needed to swap out `io.debug` for `echo`, and set the minimum stdlib version to v0.59.

I've avoided running `gleam update` etc so as to not change any other dependencies.

Thanks for a great little and really useful library!